### PR TITLE
Update ImageProcessor dependency for core

### DIFF
--- a/build/NuSpecs/UmbracoCms.Core.nuspec
+++ b/build/NuSpecs/UmbracoCms.Core.nuspec
@@ -33,8 +33,8 @@
       <dependency id="AutoMapper" version="[3.0.0, 3.1.0)" />
       <dependency id="Newtonsoft.Json" version="[6.0.8, 7.0.0)" />
       <dependency id="Examine" version="[0.1.68, 1.0.0)" />
-      <dependency id="ImageProcessor" version="[2.2.8, 3.0.0)" />
-      <dependency id="ImageProcessor.Web" version="[4.3.6, 5.0.0)" />
+      <dependency id="ImageProcessor" version="[2.3.0, 3.0.0)" />
+      <dependency id="ImageProcessor.Web" version="[4.4.0, 5.0.0)" />
       <dependency id="semver" version="[1.1.2, 2.0.0)" />
       <dependency id="Microsoft.AspNet.WebHelpers" version="[3.2.3, 4.0.0)" />
       <dependency id="Microsoft.AspNet.WebPages.Data" version="[3.2.3, 4.0.0)" />

--- a/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
+++ b/src/Umbraco.Web.UI/Umbraco.Web.UI.csproj
@@ -135,12 +135,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="ImageProcessor, Version=2.2.8.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.2.2.8.0\lib\net45\ImageProcessor.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="ImageProcessor.Web, Version=4.3.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ImageProcessor.Web.4.3.6.0\lib\net45\ImageProcessor.Web.dll</HintPath>
+    <Reference Include="ImageProcessor, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.2.3.0.0\lib\net45\ImageProcessor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Umbraco.Web.UI/packages.config
+++ b/src/Umbraco.Web.UI/packages.config
@@ -5,8 +5,8 @@
   <package id="ClientDependency-Mvc5" version="1.8.0.0" targetFramework="net45" />
   <package id="dotless" version="1.4.1.0" targetFramework="net45" />
   <package id="Examine" version="0.1.68.0" targetFramework="net45" />
-  <package id="ImageProcessor" version="2.2.8.0" targetFramework="net45" />
-  <package id="ImageProcessor.Web" version="4.3.6.0" targetFramework="net45" />
+  <package id="ImageProcessor" version="2.3.0.0" targetFramework="net45" />
+  <package id="ImageProcessor.Web" version="4.4.0.0" targetFramework="net45" />
   <package id="log4net-mediumtrust" version="2.0.0" targetFramework="net45" />
   <package id="Lucene.Net" version="2.9.4.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />


### PR DESCRIPTION
An update to U4-7053. Reduced memory usage plus web optimised images.